### PR TITLE
Fix double C-D quit issue

### DIFF
--- a/src/command_executor.cc
+++ b/src/command_executor.cc
@@ -30,6 +30,7 @@ int CommandExecutor::ProcessChild(const std::string &command,
   // should not execute to here if success
   if (ret == ERROR_CODE_SYSTEM) {
     utils::PrintSystemError(std::cerr);
+    exit(ERROR_CODE_DEFAULT);
   }
   return ERROR_CODE_DEFAULT;
 }

--- a/src/shell.cc
+++ b/src/shell.cc
@@ -28,7 +28,9 @@ void Shell::Process() {
     if (line_ptr == nullptr) {
       break;
     }
-    add_history(line_ptr);
+    if (strlen(line_ptr) > 0) {
+      add_history(line_ptr);
+    }
     std::string line = line_ptr;
     free(line_ptr);
     if (line.empty()) {


### PR DESCRIPTION
# What
See https://github.com/superxcgm/xcShell/issues/25

## Cause
child process do not auto quit correctly when `exec` failed. So, first C-D send to child process, and the second C-D send to parent process.